### PR TITLE
fix: replace to backtick for placeholder

### DIFF
--- a/src/ryu-cho.ts
+++ b/src/ryu-cho.ts
@@ -149,7 +149,7 @@ export class RyuCho {
 
     this.repo.updateRemote(shortHash)
 
-    const ref = issueNo ? '(#${issueNo})' : ''
+    const ref = issueNo ? `(#${issueNo})` : ''
     const title = `${removeHash(feed.contentSnippet)} ${ref}`
     const body = `resolves #${issueNo}\r\nCherry picked from ${feed.link}`
     const branch = shortHash


### PR DESCRIPTION
## Description

https://github.com/vuejs-jp/vite-docs-ja/pull/186

> `docs: config hook is async (#${issueNo})`

タイトルに含めている Issue No が変数展開されていませんでした。

## Proposed Solution

バックティックではなくシングルクォートになっていたのを修正します。

## Additional Information
